### PR TITLE
#816 - allow teacher to add default steps

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -53,8 +53,12 @@ class Editor extends Component {
         if (this.props.example) {
             this.props.loadExampleProblem(exampleProblem);
         } else {
-            const { action, code } = this.props.match.params;
-            this.props.loadProblem(action, code);
+            const { action, code, position } = this.props.match.params;
+            if (position) {
+                this.props.requestProblemSet(action, code, position);
+            } else {
+                this.props.loadProblem(action, code);
+            }
         }
         this.setState({
             actionsStack: [],

--- a/src/components/Home/components/Navigation/Problem/index.js
+++ b/src/components/Home/components/Navigation/Problem/index.js
@@ -108,7 +108,9 @@ export default class Problem extends Component {
     buildProblemText = () => `$$${this.props.problem.text}$$`
 
     getLink = () => {
-        const { action, solutions, problem } = this.props;
+        const {
+            action, solutions, problem, code,
+        } = this.props;
         if (this.props.example) {
             return '/#/app/problem/example/';
         }
@@ -121,6 +123,9 @@ export default class Problem extends Component {
                     return `/#/app/problem/edit/${currentSolution.editCode}`;
                 }
                 return `/#/app/problem/view/${currentSolution.shareCode}`;
+            }
+            if (action === 'edit') {
+                return `/#/app/problemSet/edit/${code}/${problem.position}`;
             }
         }
         return null;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -439,6 +439,11 @@ class App extends Component {
                             />
                             <Route
                                 exact
+                                path="/app/problemSet/:action/:code/:position"
+                                render={p => <Editor {...commonProps} {...p} {...this} />}
+                            />
+                            <Route
+                                exact
                                 path="/app/problem/:action/:code"
                                 render={p => <Editor {...commonProps} {...p} {...this} />}
                             />

--- a/src/redux/problem/sagas.js
+++ b/src/redux/problem/sagas.js
@@ -19,10 +19,16 @@ import {
     getState,
 } from './selectors';
 import {
+    matchCurrentRoute,
+} from '../router/selectors';
+import {
     fetchProblemSolutionApi,
     updateProblemSolutionApi,
     updateProblemSolutionSetApi,
 } from './apis';
+import {
+    updateProblemStepsInSet,
+} from '../problemList/apis';
 import {
     getState as getProblemListState,
 } from '../problemList/selectors';
@@ -56,24 +62,40 @@ function* requestLoadProblemSaga() {
             if (response.status !== 200) {
                 yield put(setProblemNotFound());
             } else {
-                const solution = response.data;
-                yield put(updateProblemSolution(solution, true));
-                const {
-                    theActiveMathField,
-                } = yield select(getProblemListState);
-                theActiveMathField.$latex(solution.steps[solution.steps.length - 1].stepValue);
-                yield put(setSolutionData(solution, action));
-                const {
-                    problemSetSolutionEditCode,
-                } = solution;
-                if (problemSetSolutionEditCode) {
-                    yield put(loadProblemSetSolutionByEditCode(problemSetSolutionEditCode));
-                }
+                yield put({
+                    type: 'PROCESS_FETCHED_PROBLEM',
+                    payload: {
+                        action,
+                        solution: response.data,
+                    },
+                });
             }
             // yield put(push(`/app/problemSet/view/${revisionCode}`));
         } catch (error) {
             // dispatch a failure action to the store with the error
             yield put(setProblemNotFound());
+        }
+    });
+}
+
+function* processFetchedProblem() {
+    yield takeLatest('PROCESS_FETCHED_PROBLEM', function* workerSaga({
+        payload: {
+            action,
+            solution,
+        },
+    }) {
+        yield put(updateProblemSolution(solution, true));
+        const {
+            theActiveMathField,
+        } = yield select(getProblemListState);
+        theActiveMathField.$latex(solution.steps[solution.steps.length - 1].stepValue);
+        yield put(setSolutionData(solution, action));
+        const {
+            problemSetSolutionEditCode,
+        } = solution;
+        if (problemSetSolutionEditCode) {
+            yield put(loadProblemSetSolutionByEditCode(problemSetSolutionEditCode));
         }
     });
 }
@@ -115,7 +137,22 @@ function* requestCommitProblemSolutionSaga() {
             } = yield select(getState);
             const problemListState = yield select(getProblemListState);
             let shareCode = '';
-            if (problemListState.editCode) {
+            const matchedRoute = yield select(
+                matchCurrentRoute('/app/problemSet/:action/:editCode/:position'),
+            );
+            if (matchedRoute) {
+                const { steps } = solution;
+                const { params } = matchedRoute;
+                const { editCode } = params;
+                const problemId = solution.problem.id;
+                const response = yield call(
+                    updateProblemStepsInSet, editCode, problemId, steps,
+                );
+                if (response.status !== 201) {
+                    alertError('Unable to save problem', 'Error');
+                    return;
+                }
+            } else if (problemListState.editCode) {
                 const payloadSolutions = problemListState.solutions.map((currentSolution) => {
                     if (currentSolution.problem.id === solution.problem.id) {
                         return solution;
@@ -144,38 +181,47 @@ function* requestCommitProblemSolutionSaga() {
                     shareCode = updatedSolution.shareCode;
                 }
             } else {
-                const response = yield call(updateProblemSolutionApi, solution.editCode, solution);
-                if (response.status !== 200) {
+                const response = yield call(
+                    updateProblemSolutionApi, solution.editCode, solution,
+                );
+                if (response.status !== 201) {
                     alertError('Unable to update problem set solution', 'Error');
                     return;
                 }
                 yield put(updateProblemSolution(response.data));
                 shareCode = response.data.shareCode;
             }
+            let problemStorePayload = {
+                stepsFromLastSave: JSON.parse(JSON.stringify(solution.steps)),
+                lastSaved: (new Date().toLocaleString('en-US', {
+                    hour: 'numeric',
+                    minute: 'numeric',
+                    hour12: true,
+                })),
+                isUpdated: false,
+            };
             if (!shareModal) {
-                yield put(updateProblemStore({
+                problemStorePayload = {
+                    ...problemStorePayload,
                     editLink: `${FRONTEND_URL}/app/problem/edit/${solution.editCode}`,
                     shareLink: `${FRONTEND_URL}/app/problem/view/${shareCode}`,
-                    stepsFromLastSave: JSON.parse(JSON.stringify(solution.steps)),
-                    lastSaved: (new Date().toLocaleString('en-US', {
-                        hour: 'numeric',
-                        minute: 'numeric',
-                        hour12: true,
-                    })),
-                    isUpdated: false,
-                }));
+                };
             }
+            yield put(updateProblemStore(problemStorePayload));
+
             alertSuccess(Locales.strings.problem_saved_success_message,
                 Locales.strings.success);
 
             if (redirectBack) {
                 yield put(goBack());
             }
-            if (shareModal) {
-                yield put(updateProblemStore({
-                    shareLink: `${FRONTEND_URL}/app/problem/view/${shareCode}`,
-                }));
-                yield put(toggleModals([SHARE_SET]));
+            if (!matchedRoute && shareCode) {
+                if (shareModal) {
+                    yield put(updateProblemStore({
+                        shareLink: `${FRONTEND_URL}/app/problem/view/${shareCode}`,
+                    }));
+                    yield put(toggleModals([SHARE_SET]));
+                }
             }
         } catch (error) {
             // dispatch a failure action to the store with the error
@@ -191,6 +237,7 @@ function* requestCommitProblemSolutionSaga() {
 
 export default function* rootSaga() {
     yield all([
+        fork(processFetchedProblem),
         fork(requestLoadProblemSaga),
         fork(updateProblemSolutionSaga),
         fork(requestCommitProblemSolutionSaga),

--- a/src/redux/problemList/actions.js
+++ b/src/redux/problemList/actions.js
@@ -8,11 +8,12 @@ export const requestExampleSets = () => ({
     type: 'REQUEST_EXAMPLE_SETS',
 });
 
-export const requestProblemSet = (action, code) => ({
+export const requestProblemSet = (action, code, position) => ({
     type: 'REQUEST_PROBLEM_SET',
     payload: {
         action,
         code,
+        position,
     },
 });
 

--- a/src/redux/problemList/apis.js
+++ b/src/redux/problemList/apis.js
@@ -39,6 +39,8 @@ export const updateProblemsApi = (editCode, shareCode, problems, title) => axios
 
 export const saveProblemSetApi = set => axios.post(`${SERVER_URL}/problemSet/`, set, commonRequestConfig);
 
+export const updateProblemStepsInSet = (editCode, problemId, steps) => axios.put(`${SERVER_URL}/problemSet/${editCode}/steps/${problemId}`, steps, commonRequestConfig);
+
 export const fetchEditableProblemSetSolutionApi = editCode => axios.get(`${SERVER_URL}/solution/solve/${editCode}`, commonRequestConfig);
 
 export default {
@@ -47,6 +49,7 @@ export default {
     fetchProblemsByRevisionCodeApi,
     fetchProblemsByReviewCodeApi,
     updateProblemsApi,
+    updateProblemStepsInSet,
     saveProblemSetApi,
     fetchEditableProblemSetSolutionApi,
 };

--- a/src/services/review.js
+++ b/src/services/review.js
@@ -26,6 +26,12 @@ export const shareSolutions = (code, payloadSolutions) => axios.post(`${SERVER_U
     });
 
 export const getSolutionObjectFromProblems = problems => problems.map((problem) => {
+    if (problem.steps.length > 0) {
+        return {
+            problem,
+            steps: problem.steps,
+        };
+    }
     const step = {
         explanation: problem.title,
         stepValue: problem.text,


### PR DESCRIPTION
This PR is related to https://github.com/benetech/MathShare/issues/816

Here changes have been made in the Problem Set creation flow so that teacher can click on the Problem in the set and add default steps in it which will be pre-populated for the students.

There are no HTML changes in this PR, existing view has been reused.