### PR TITLE
minor css fixes

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -54,6 +54,7 @@ import msalConfig from '../constants/msal';
 import keyMap from '../constants/hotkeyConfig.json';
 import { stopEvent, passEventForKeys } from '../services/events';
 import { getPathTo } from '../services/dom';
+import './styles.scss';
 
 
 const mathLive = process.env.MATHLIVE_DEBUG_MODE

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -1,0 +1,13 @@
+:global(#contentContainer) {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+
+    > :global(.body-container) {
+        flex: 1 0 auto;
+    }
+
+    > :global(footer#footer) {
+        margin-top: auto;
+    }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,7 @@
 <body lang=EN-US>
     <div id="root" style="height: 100%; 
         display: flex;
-        overflow: scroll;
+        overflow-y: scroll;
         justify-content: space-between;
         flex-direction: column;
         z-index: 1;


### PR DESCRIPTION
these css fixes are mainly for making the footer stick to bottom when less content is present and also to remove a horizontal scrollbar on landing page which was shown only on windows